### PR TITLE
version update for the swagger allOf key in subGroups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-parser</artifactId>
-			<version>1.0.31</version>
+			<version>1.0.49</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -934,6 +934,11 @@
         "name",
         "photoUrls"
       ],
+      "allOf": [
+        {
+           "$ref": "#/definitions/ExampleAllOf"
+        }
+     ],
       "properties": {
         "id": {
           "type": "integer",
@@ -1000,7 +1005,16 @@
           "type": "string"
         }
       }
-    }
+    },
+    "ExampleAllOf": {
+      "type": "object",
+      "description": "allOf example",
+      "properties": {
+         "test": {
+          "type": "string"
+         }
+      }
+   }
   },
   "externalDocs": {
     "description": "Find out more about Swagger",

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -930,6 +930,11 @@
         "name",
         "photoUrls"
       ],
+      "allOf": [
+        {
+           "$ref": "#/definitions/ExampleAllOf"
+        }
+     ],
       "properties": {
         "id": {
           "type": "integer",
@@ -1001,7 +1006,16 @@
           "type": "string"
         }
       }
-    }
+    },
+    "ExampleAllOf": {
+      "type": "object",
+      "description": "allOf example",
+      "properties": {
+         "test": {
+          "type": "string"
+         }
+      }
+   }
   },
   "externalDocs": {
     "description": "Find out more about Swagger",


### PR DESCRIPTION
Hey,
You have solved most problems. But I noticed something. If swagger document contains any allOf key, for the references or sub-references swagger-parser library can not handle mapping properties. I solved this problem simply by updating the library.

Have a good day.